### PR TITLE
 Change instance type for development to small

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,8 @@
 {
   "editor.formatOnSave": true,
-  "cSpell.words": ["hollowverse"],
+  "cSpell.words": [
+    "Terraform",
+    "hollowverse"
+  ],
   "editor.tabSize": 2
 }

--- a/db.tf
+++ b/db.tf
@@ -100,7 +100,7 @@ resource "aws_rds_cluster_instance" "cluster_instance_0" {
 
   cluster_identifier = "${aws_rds_cluster.db_cluster.id}"
 
-  instance_class      = "${var.stage == "production" ? "db.t2.medium" : "db.t2.micro"}"
+  instance_class      = "${var.stage == "production" ? "db.t2.medium" : "db.t2.small"}"
   publicly_accessible = true
 
   engine = "aurora-mysql"


### PR DESCRIPTION
`db.t2.micro` is not supported by Aurora (at least in `us-east-1`).